### PR TITLE
Feat: Add support for snapshot warning events

### DIFF
--- a/rust-server/html/report_variabled.html
+++ b/rust-server/html/report_variabled.html
@@ -217,6 +217,7 @@
               <ul class="small">
                 <li>Total Events: {{TOTAL_EVENTS}}</li>
                 <li>Total Snapshots: {{TOTAL_SNAPSHOT_SUCCESS}}</li>
+                <li>Snapshot Warnings: {{TOTAL_SNAPSHOT_WARNING}}</li>
                 <li>Snapshot Failures: {{TOTAL_SNAPSHOT_ERROR}}</li>
                 <li>Forget Operations: {{TOTAL_FORGET_SUCCESS}}</li>
                 <li>Forget Failures: {{TOTAL_FORGET_ERROR}}</li>

--- a/rust-server/html/warn_snapshot.html
+++ b/rust-server/html/warn_snapshot.html
@@ -1,7 +1,7 @@
 <td class="card-cell">
-    <div class="card error">
+    <div class="card warn">
         <h2><span class="icon">⚠️</span>{{SNAPSHOT_PLAN}}</h2>
-        <p><strong>ERROR:</strong> <code>{{SNAPSHOT_SUMMARY_ID}}...</code></p>
+        <p><strong>WARNING:</strong> <code>{{SNAPSHOT_SUMMARY_ID}}...</code></p>
         <p class="small">{{SNAPSHOT_TIME}}</p>
         <ul class="small">
             <li>&nbsp;</li>

--- a/rust-server/src/handlers.rs
+++ b/rust-server/src/handlers.rs
@@ -409,6 +409,7 @@ pub async fn fetch_event_totals(
 
           COALESCE(COUNT(*)                                                           , 0)::BIGINT AS total_events,
           COALESCE(SUM(CASE WHEN s.event ILIKE '%snapshot success%' THEN 1 ELSE 0 END), 0)::BIGINT AS total_snapshot_success,
+          COALESCE(SUM(CASE WHEN s.event ILIKE '%snapshot warning%' THEN 1 ELSE 0 END), 0)::BIGINT AS total_snapshot_warning,
           COALESCE(SUM(CASE WHEN s.event ILIKE '%snapshot error%'   THEN 1 ELSE 0 END), 0)::BIGINT AS total_snapshot_error,
           COALESCE(SUM(CASE WHEN s.event ILIKE '%forget success%'   THEN 1 ELSE 0 END), 0)::BIGINT AS total_forget_success,
           COALESCE(SUM(CASE WHEN s.event ILIKE '%forget error%'     THEN 1 ELSE 0 END), 0)::BIGINT AS total_forget_error,

--- a/rust-server/src/html_report.rs
+++ b/rust-server/src/html_report.rs
@@ -17,6 +17,8 @@ pub fn render_report_html(cfg: &Config, report: &GenerateReport) -> Result<Strin
         .map_err(|_| "Failed to read HTML template")?;
     let success_tmpl = fs::read_to_string("html/success_snapshot.html")
         .map_err(|_| "Failed to read success snapshot template")?;
+    let warn_tmpl = fs::read_to_string("html/warn_snapshot.html")
+        .map_err(|_| "Failed to read warn snapshot template")?;
     let error_tmpl   = fs::read_to_string("html/error_snapshot.html")
         .map_err(|_| "Failed to read error snapshot template")?;
     let row_tmpl     = fs::read_to_string("html/snapshot_status_row.html")
@@ -31,6 +33,7 @@ pub fn render_report_html(cfg: &Config, report: &GenerateReport) -> Result<Strin
     for summary in &report.snapshot_summaries {
         let tpl = match summary.event.as_str() {
             "snapshot success" => &success_tmpl,
+            "snapshot warning" => &warn_tmpl,
             "snapshot error"   => &error_tmpl,
             _                  => continue, // skip other events
         };

--- a/rust-server/src/html_report.rs
+++ b/rust-server/src/html_report.rs
@@ -41,7 +41,15 @@ pub fn render_report_html(cfg: &Config, report: &GenerateReport) -> Result<Strin
         // assume success_tmpl and error_tmpl have placeholders like {{ID}}, {{TIME}}, {{MESSAGE}}
         let mut entry = tpl.clone();
         entry = entry.replace("{{SNAPSHOT_PLAN}}", &summary.plan.to_string());
-        entry = entry.replace("{{SNAPSHOT_SUMMARY_ID}}", &summary.snapshot.to_string()[..10]);
+        
+        let replacement: &str = if summary.snapshot.is_empty() || summary.snapshot == "null" {
+            "N/A" // if it's empty or the literal "null"
+        } else {
+            // otherwise, take up to 10 characters
+            &summary.snapshot[..summary.snapshot.len().min(10)]
+        };
+        entry = entry.replace("{{SNAPSHOT_SUMMARY_ID}}", replacement);
+
         entry = entry.replace("{{SNAPSHOT_TIME}}", &format_local_datetime(summary.created_at));
         entry = entry.replace(
             "{{SNAPSHOT_NEW_FILES}}",
@@ -114,6 +122,7 @@ pub fn render_report_html(cfg: &Config, report: &GenerateReport) -> Result<Strin
     let et = &report.event_totals.current;
     replacements.push(("{{TOTAL_EVENTS}}",           et.total_events.to_string()));
     replacements.push(("{{TOTAL_SNAPSHOT_SUCCESS}}", et.total_snapshot_success.to_string()));
+    replacements.push(("{{TOTAL_SNAPSHOT_WARNING}}", et.total_snapshot_warning.to_string()));
     replacements.push(("{{TOTAL_SNAPSHOT_ERROR}}",   et.total_snapshot_error.to_string()));
     replacements.push(("{{TOTAL_FORGET_SUCCESS}}",   et.total_forget_success.to_string()));
     replacements.push(("{{TOTAL_FORGET_ERROR}}",     et.total_forget_error.to_string()));

--- a/rust-server/src/models.rs
+++ b/rust-server/src/models.rs
@@ -97,6 +97,7 @@ pub struct EventTotals {
 
     pub total_events:            i64,
     pub total_snapshot_success:  i64,
+    pub total_snapshot_warning:  i64,
     pub total_snapshot_error:    i64,
     pub total_forget_success:    i64,
     pub total_forget_error:      i64,


### PR DESCRIPTION
**Summary**
- Adding support for snapshot warning events
- Adding total 'summary warning' events to report
- Updating handling for snapshots with `error`s and their html template

**Examples**
- Example warning event:
    ![image](https://github.com/user-attachments/assets/74115809-d14f-408b-a325-f413b0db8325)
- Example error event:
    ![image](https://github.com/user-attachments/assets/0d66a7ff-6316-4af3-8441-a437efaf8190)

