### PR TITLE
Feat: Add optional startup email controllable via env flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,8 @@ NUM_RETAINED_REPORTS=10                                      # Number of retaine
 
 HEALTHCHECK_PING_URL=https://hc-ping.com/ping/ping-key/slug  # Optional healthcheck URL
 
+SEND_STARTUP_EMAIL=False                                     # Optional email when the container is started. Set to `TRUE` or `1` to enable.
+
 ####################################
 # Rclone Mount Configuration (If Using an Rclone-Mounter)
 ####################################

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ At this point, you can [test additional endpoints](#endpoints) and setting up th
 | **SMTP\_PASSWORD**         | SMTP password or app-specific password (never use your main email password)                                | Required                                            |
 | **EMAIL\_FROM**            | Email address and display name emails will be sent from (e.g. `Your App Name <you@example.com>`)           | Required                                            |
 | **EMAIL\_TO**              | Comma-separated list of recipient email addresses                                                          | Required                                            |
+| **SEND\_STARTUP\_EMAIL**   | Flag for sending email when system is first online. Set to `TRUE` or `1` to enable.                        | Optional • Default: None (`False`)                                           |
 | **EMAIL\_FREQUENCY**       | Cron schedule in UTC (e.g., `0 0 0 * * *` runs daily at midnight UTC)                                      | Optional • Default: `0 0 0 * * *`                   |
 | **STATS\_INTERVAL**        | Interval (in hours) of backup data to include in the email (e.g., `24` = last 24 hours)                    | Optional • Default: `24`                            |
 | **NUM\_RETAINED\_REPORTS** | Number of retained reports stored; oldest are deleted first when exceeding this number                     | Optional • Default: `10`                            |
@@ -234,6 +235,8 @@ curl -X POST https://your-backrest-reporter-instance/send-test-email \
 ```
 
 Check your Gmail inbox (or Spam folder) to verify the report is being sent.
+
+You can also enable `SEND_STARTUP_EMAIL` in your `.env` by setting it to `TRUE` or `1`. Doing so enables a startup email when the container is brought online. It contains the container ID and next report generation time. This can be useful for detecting automated updates to the container or unexpected outages.
 
 ### Tips
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -42,6 +42,7 @@ services:
       EMAIL_FREQUENCY: "${EMAIL_FREQUENCY}"
       STATS_INTERVAL: "${STATS_INTERVAL}"
       NUM_RETAINED_REPORTS: "${NUM_RETAINED_REPORTS}"
+      SEND_STARTUP_EMAIL: "${SEND_STARTUP_EMAIL}"
 
       # Storage mount paths and nicknames (these paths must exist in the container)
       # Can supply as many as desired using the naming convention, starting at 1

--- a/docker-examples/docker-compose-backrest.yaml
+++ b/docker-examples/docker-compose-backrest.yaml
@@ -83,7 +83,8 @@ services:
       SMTP_PASSWORD: ${SMTP_PASSWORD}
       EMAIL_FROM: ${EMAIL_FROM}
       EMAIL_TO: ${EMAIL_TO}
-
+      SEND_STARTUP_EMAIL: "${SEND_STARTUP_EMAIL}"
+      
       # Email scheduling and report configuration
       EMAIL_FREQUENCY: "${EMAIL_FREQUENCY}"
       STATS_INTERVAL: "${STATS_INTERVAL}"

--- a/docker-examples/docker-compose-rclone.yaml
+++ b/docker-examples/docker-compose-rclone.yaml
@@ -83,7 +83,8 @@ services:
       SMTP_PASSWORD: ${SMTP_PASSWORD}
       EMAIL_FROM: ${EMAIL_FROM}
       EMAIL_TO: ${EMAIL_TO}
-
+      SEND_STARTUP_EMAIL: "${SEND_STARTUP_EMAIL}"
+      
       # Email scheduling and report configuration
       EMAIL_FREQUENCY: "${EMAIL_FREQUENCY}"
       STATS_INTERVAL: "${STATS_INTERVAL}"

--- a/docker-examples/docker-compose-rsync-cron.yaml
+++ b/docker-examples/docker-compose-rsync-cron.yaml
@@ -48,7 +48,8 @@ services:
       SMTP_PASSWORD: ${SMTP_PASSWORD}
       EMAIL_FROM: ${EMAIL_FROM}
       EMAIL_TO: ${EMAIL_TO}
-
+      SEND_STARTUP_EMAIL: "${SEND_STARTUP_EMAIL}"
+      
       # Healthchecks ping url for API status
       HEALTHCHECK_PING_URL: ${HEALTHCHECK_PING_URL}
 

--- a/docker-examples/docker-compose-source.yaml
+++ b/docker-examples/docker-compose-source.yaml
@@ -36,7 +36,8 @@ services:
       SMTP_PASSWORD: ${SMTP_PASSWORD}
       EMAIL_FROM: ${EMAIL_FROM}
       EMAIL_TO: ${EMAIL_TO}
-
+      SEND_STARTUP_EMAIL: "${SEND_STARTUP_EMAIL}"
+      
       # Healthchecks ping url for API status
       HEALTHCHECK_PING_URL: ${HEALTHCHECK_PING_URL}
 

--- a/rust-server/html/startup_email.html
+++ b/rust-server/html/startup_email.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+   <head>
+      <meta charset="UTF-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+      <title>Backrest Summary Reporter Online</title>
+      <style>
+         /* Simplified CSS without variables */
+         * { box-sizing: border-box; margin: 0; padding: 0; }
+         body {
+         font-family: Arial, sans-serif;
+         background: #f9f9f9;
+         color: #404040;
+         line-height: 1.5;
+         padding: 16px;
+         }
+         a { color: #0066cc; text-decoration: none; }
+         a:hover { text-decoration: underline; }
+         .container {
+         max-width: 800px;
+         margin: 0 auto;
+         background: #fff;
+         border-radius: 6px;
+         overflow: hidden;
+         }
+         header {
+         background: #e0e0e0;
+         padding: 16px;
+         text-align: center;
+         }
+         header h1 { font-size: 1.5rem; margin-bottom: 8px; color: #404040; }
+         header p { color: #606060; font-size: 0.9rem; }
+         .content {
+         padding: 16px;
+         }
+         .content p { margin-bottom: 12px; font-size: 0.9rem; }
+         .button {
+         display: inline-block;
+         padding: 10px 20px;
+         background: #0066cc;
+         color: #fff;
+         text-decoration: none;
+         border-radius: 4px;
+         font-size: 0.9rem;
+         }
+         .footer {
+         background: #f0f0f0;
+         padding: 16px;
+         text-align: center;
+         font-size: 0.8rem;
+         color: #606060;
+         }
+         @media screen and (max-width: 600px) {
+         .container { width: 100% !important; }
+         .button { width: 100%; text-align: center; }
+         }
+      </style>
+   </head>
+   <body>
+      <div class="container">
+         <header>
+            <h1>Backrest Summary Reporter Online (<code>{{HOSTNAME}}</code>)</h1>
+         </header>
+         <div class="content">
+            <p>Hostname: <code>{{HOSTNAME}}</code></p>
+            <p>All systems are online. The next summary report will be at <strong>{{NEXT_REPORT}}</strong>.</p>
+         </div>
+         <!-- footer -->
+         <div class="footer">
+            <p>Report generated on: <strong>{{TIMESTAMP}}</strong></p>
+            <p>
+               <a href="{{BACKREST_URL}}">Backrest</a> |
+               <a href="{{PGADMIN_URL}}">PG Admin</a> |
+               <a href="https://github.com/estes-sj/Backrest-Summary-Reporter">GitHub</a>
+            </p>
+         </div>
+      </div>
+   </body>
+</html>

--- a/rust-server/src/config.rs
+++ b/rust-server/src/config.rs
@@ -23,6 +23,7 @@ pub struct Config {
     pub smtp_password: Option<String>,
     pub email_from: Option<String>,
     pub email_to: Option<String>,
+    pub send_startup_email: bool,
 
     // --- Healthcheck settings (optional) ---
     pub healthcheck_url: Option<String>,
@@ -81,6 +82,18 @@ impl Config {
         let email_from    = env::var("EMAIL_FROM").ok();
         let email_to      = env::var("EMAIL_TO").ok();
 
+        // Optional startup email
+        // Map the String to bool by lowercasing and comparing
+        // Set to false as default
+        let send_startup_email = env::var("SEND_STARTUP_EMAIL")
+            .map(|s| {
+                let val = s.to_lowercase();
+                // treat "true" or "1" as true (everything else = false)
+                val == "true" || val == "1"
+            })
+            // If the var wasn't set, default to false
+            .unwrap_or(false);
+
         // Optional storage mounts
         let mut storage_mounts = Vec::new();
         for idx in 1.. {
@@ -133,6 +146,7 @@ impl Config {
             smtp_password,
             email_from,
             email_to,
+            send_startup_email,
             healthcheck_url,
             storage_mounts,
             server_name,

--- a/rust-server/src/scheduler.rs
+++ b/rust-server/src/scheduler.rs
@@ -1,12 +1,14 @@
 use chrono::{DateTime, Local, Utc, Duration as ChronoDuration};
 use cron::Schedule;
 use reqwest::Client;
-use std::str::FromStr;
+use std::{fs, str::FromStr};
 use tokio_cron_scheduler::{Job, JobScheduler};
 use tracing::{info, error};
 use crate::{
     fail, ok,
     config::Config,
+    email::{EmailClient},
+    utils::{container_id_from_hostname},
 };
 
 
@@ -15,59 +17,108 @@ pub async fn spawn_email_report_cron(cfg: Config) {
     // clone once for the async task
     let cfg = cfg.clone();
     let http = Client::new();
-
+    
     tokio::spawn(async move {
         // 1) Preview next run via `cron::Schedule`
         let schedule = Schedule::from_str(&cfg.email_frequency)
-            .expect("Invalid cron expression in EMAIL_FREQUENCY");
-
+        .expect("Invalid cron expression in EMAIL_FREQUENCY");
+        
         // Pull the next run in UTC
         let next_utc: DateTime<Utc> = schedule
-            .upcoming(Utc)
-            .next()
-            .expect("Unable to compute next schedule");
-
+        .upcoming(Utc)
+        .next()
+        .expect("Unable to compute next schedule");
+        
         // Convert to local zone for display
         let next_local: DateTime<Local> = next_utc.with_timezone(&Local);
-
+        
         ok!(
             cfg,
             "System online. Next email report is at {}",
             next_local.format("%a, %b %e %Y at %I:%M:%S %p %:z")
         );
-
-        // 2) Build the actual scheduler
+        
+        // 2) Only send a startup email if configured to do so
+        if cfg.send_startup_email {
+            // Attempt to build an EmailClient from your SMTP config
+            match EmailClient::from_config(&cfg) {
+                Ok(client) => {
+                    // Read the startup email HTML template
+                    let mut html = match fs::read_to_string("html/startup_email.html") {
+                        Ok(s) => s,
+                        Err(err) => {
+                            error!("Failed to read HTML template: {}", err);
+                            return;
+                        }
+                    };
+                    
+                    // Replace any placeholders—e.g. timestamp, URLs, etc.
+                    html = html.replace("{{HOSTNAME}}", &container_id_from_hostname());
+                    html = html.replace("{{NEXT_REPORT}}", &next_local.format("%a, %b %e %Y at %I:%M:%S %p %:z").to_string());
+                    
+                    let timestamp_str = Local::now().format("%d/%m/%Y at %I:%M %p").to_string();
+                    html = html.replace("{{TIMESTAMP}}", &timestamp_str);
+                    html = html.replace(
+                        "{{BACKREST_URL}}",
+                        &cfg.backrest_url.clone().unwrap_or_default(),
+                    );
+                    html = html.replace(
+                        "{{PGADMIN_URL}}",
+                        &cfg.pgadmin_url.clone().unwrap_or_default(),
+                    );
+                    
+                    // Build and send the email
+                    if let Err(err) = client.send_html("🚀 Server Startup", html, &cfg).await {
+                        error!("Failed to send startup email: {:?}", err);
+                    } else {
+                        info!(
+                            "Startup email successfully sent to {}",
+                            cfg.email_to.as_deref().unwrap_or("<unset>")
+                        );
+                    }
+                }
+                Err(err) => {
+                    error!(
+                        "Unable to construct EmailClient for startup email: {:?}",
+                        err
+                    );
+                }
+            }
+        }
+        
+        
+        // 3) Build the actual scheduler
         let mut sched = JobScheduler::new();
-
-        // 3) Define and add the job
+        
+        // 4) Define and add the job
         let job = Job::new_async(&cfg.email_frequency, move |_uuid, _l| {
             // Clone what we need before the async block
             let api_key  = cfg.auth_key.clone();
             let http     = http.clone();
             let port     = cfg.listen_addr.port();
             let interval = cfg.stats_interval;
-
+            
             Box::pin(async move {
                 // Compute the time window
                 let end   = Utc::now();
                 let start = end - ChronoDuration::hours(interval);
-
+                
                 let body = serde_json::json!({
                     "start_date": start.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
                     "end_date":   end  .to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
                 });
-
+                
                 let url = format!(
                     "http://localhost:{}/generate-and-send-email-report",
                     port
                 );
-
+                
                 match http
-                    .post(&url)
-                    .header("X-API-Key", api_key)
-                    .json(&body)
-                    .send()
-                    .await
+                .post(&url)
+                .header("X-API-Key", api_key)
+                .json(&body)
+                .send()
+                .await
                 {
                     Ok(_) => info!("Scheduled report triggered at {}", Local::now().to_rfc3339()),
                     Err(e) => error!(
@@ -79,10 +130,10 @@ pub async fn spawn_email_report_cron(cfg: Config) {
             })
         })
         .expect("Invalid cron expression");
-
+        
         sched.add(job).expect("Failed to add email cron job");
-
-        // 4) Start the scheduler loop
+        
+        // 5) Start the scheduler loop
         sched.start().await.expect("Scheduler failed to start");
     });
 }
@@ -93,22 +144,22 @@ pub async fn spawn_storage_update_cron(cfg: Config) {
     // clone for the task
     let cfg = cfg.clone();
     let http = Client::new();
-
+    
     tokio::spawn(async move {
         let port = cfg.listen_addr.port();
         let url = format!("http://localhost:{}/update-storage-statistics", port);
         let ts_fmt = "%a, %b %e %Y at %I:%M:%S %p %:z";
-
+        
         // Immediate storage stats update
         {
             let api_key = cfg.auth_key.clone();
             let now = Local::now().format(ts_fmt).to_string();
-
+            
             match http
-                .get(&url)
-                .header("X-API-Key", api_key)
-                .send()
-                .await
+            .get(&url)
+            .header("X-API-Key", api_key)
+            .send()
+            .await
             {
                 Ok(resp) if resp.status().is_success() => {
                     info!("Startup storage stats update succeeded at {}", now);
@@ -124,43 +175,43 @@ pub async fn spawn_storage_update_cron(cfg: Config) {
                 ),
             }
         }
-
+        
         // Preview next run
         let expr = "0 0 0 * * *"; // quartz 6-field: sec=0, min=0, hour=0, daily
         let schedule = Schedule::from_str(expr)
-            .expect("Invalid cron expression for storage update");
+        .expect("Invalid cron expression for storage update");
         
         // Pull the next run in UTC
         let next_utc: DateTime<Utc> = schedule
-            .upcoming(Utc)
-            .next()
-            .expect("Unable to compute next schedule");
-
+        .upcoming(Utc)
+        .next()
+        .expect("Unable to compute next schedule");
+        
         // Convert to local zone for display
         let next_local: DateTime<Local> = next_utc.with_timezone(&Local);
-
+        
         info!(
             "Next storage stats update is at {}",
             next_local.format(ts_fmt)
         );
-
+        
         // Build scheduler
         let mut sched = JobScheduler::new();
-
+        
         // Build and add the job
         let job = Job::new_async(expr, move |_uuid, _l| {
             // clone inside closure
             let api_key = cfg.auth_key.clone();
             let http    = http.clone();
             let url     = url.clone();
-
+            
             Box::pin(async move {
                 let now = Local::now().format(&ts_fmt).to_string();
                 match http
-                    .get(&url)
-                    .header("X-API-Key", api_key)
-                    .send()
-                    .await
+                .get(&url)
+                .header("X-API-Key", api_key)
+                .send()
+                .await
                 {
                     Ok(resp) if resp.status().is_success() => {
                         info!("Storage stats update succeeded at {}", now)
@@ -178,9 +229,9 @@ pub async fn spawn_storage_update_cron(cfg: Config) {
             })
         })
         .expect("Invalid cron expression for storage update");
-
+        
         sched.add(job).expect("Failed to add storage update cron job");
-
+        
         // Start the scheduler loop
         sched.start().await.expect("Scheduler failed to start");
     });

--- a/rust-server/src/utils.rs
+++ b/rust-server/src/utils.rs
@@ -1,4 +1,5 @@
 use axum::http::StatusCode;
+use std::fs;
 
 /// Log a failure, ping healthcheck(fail) with a combined message of
 /// **static** + **formatted** details, but return only the static part
@@ -98,4 +99,12 @@ macro_rules! start {
             Some(&combined),
         );
     }};
+}
+
+/// Try to read the container ID from /etc/hostname,
+/// or return `"Unknown"` if that fails.
+pub fn container_id_from_hostname() -> String {
+    fs::read_to_string("/etc/hostname")
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|_| "Unknown".into())
 }


### PR DESCRIPTION
**Summary**
- Add optional startup email, executed when setting up schedulers
- Add startup email html template
- Controllable via `SEND_STARTUP_EMAIL`
- Include notes on usage in `.env.example` and `README.md`
- Update all docker compose examples