### PR TITLE
Feat: Change storage stats Day, Week, Month to D, W, M to prevent multi-line

### DIFF
--- a/rust-server/html/storage_entry.html
+++ b/rust-server/html/storage_entry.html
@@ -62,7 +62,7 @@
         </td>
         <!-- right cell: change stats -->
         <td style="font-size:12px; color:#606060; padding-top:4px; text-align:right; vertical-align:middle;">
-            Day: {{STORAGE_USED_PREVIOUS_DAY_PERCENT_INCREASE}} | Week: {{STORAGE_USED_PREVIOUS_WEEK_PERCENT_INCREASE}} | Month: {{STORAGE_USED_PREVIOUS_MONTH_PERCENT_INCREASE}}
+            D {{STORAGE_USED_PREVIOUS_DAY_PERCENT_INCREASE}} | W {{STORAGE_USED_PREVIOUS_WEEK_PERCENT_INCREASE}} | M {{STORAGE_USED_PREVIOUS_MONTH_PERCENT_INCREASE}}
         </td>
         </tr>
     </table>


### PR DESCRIPTION
**Summary**
- Changing the storage stats section of the email to use `D`, `W`, and `M`, instead of `Day:`, `Week:`, and `Month:` to prevent multi-line on smaller screens (e.g. mobile)

[`docs/img/example_report_p2.png`](https://github.com/estes-sj/Backrest-Summary-Reporter/blob/c911e2f70fb5590307c88ebfedf30091623561d7/docs/img/example_report_p2.png) contains an example of this visual change.