### PR TITLE
Feat: Include data added for each snapshot event in email reports

### DIFF
--- a/rust-server/html/success_snapshot.html
+++ b/rust-server/html/success_snapshot.html
@@ -7,6 +7,7 @@
         <li>New files: {{SNAPSHOT_NEW_FILES}}</li>
         <li>Changed files: {{SNAPSHOT_CHANGED_FILES}}</li>
         <li>Unmodified files: {{SNAPSHOT_UNMODIFIED_FILES}}</li>
+        <li>Data added: {{SNAPSHOT_DATA_ADDED}}</li>
         <li>Total data processed: {{SNAPSHOT_TOTAL_PROCESSED}}</li>
         <li>Total duration: {{SNAPSHOT_TOTAL_DURATION}}</li>
         </ul>

--- a/rust-server/src/html_report.rs
+++ b/rust-server/src/html_report.rs
@@ -67,6 +67,11 @@ pub fn render_report_html(cfg: &Config, report: &GenerateReport) -> Result<Strin
                 .map_or("-".to_string(), |v| v.to_string()),
         );
         entry = entry.replace(
+            "{{SNAPSHOT_DATA_ADDED}}",
+            &summary.data_added
+                .map_or("-".to_string(), |v| format_bytes(v as u64)),
+        );
+        entry = entry.replace(
             "{{SNAPSHOT_TOTAL_PROCESSED}}",
             &summary.total_bytes_processed
                 .map_or("-".to_string(), |v| format_bytes(v as u64)),


### PR DESCRIPTION
**Summary**
- In addition to the total data added, include the data added for each snapshot in the email reports