### PR TITLE
Feat: Select date for storage stats and update after each snapshot event

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ At this point, you can [test additional endpoints](#endpoints) and setting up th
 | **RCLONE\_REMOTE**         | Your rclone remote name (must end with a colon, e.g. `google_drive:`)                                      | Optional                                            |
 | **RCLONE\_TARGET**         | Path inside the container where the rclone remote is mounted (e.g. `/mnt-rclone/google_drive`)             | Optional                                            |
 | **STORAGE\_PATH\_1–N**     | Inside-the-container paths where backup archives are located (e.g. `/mnt/opt`, `/mnt/mnt`)                 | Optional • At least one path if using storage stats |
-| **STORAGE\_NICK\_1–N**     | Friendly nickname for each storage path shown in reports (e.g. `sam-fedserver01-opt`, `External Drive 01`) | Optional • Defaults to path if blank                |
+| **STORAGE\_NICK\_1–N**     | Friendly nickname for each storage path shown in reports (e.g. `fedserver01-opt`, `External Drive 01`) | Optional • Defaults to path if blank                |
 | **SERVER\_NAME**           | Human-readable name of the server/environment used in email reports                                        | Optional                                            |
 | **BACKREST\_URL**          | URL to Backrest backup management UI/API used in email reports (e.g. `https://backrest.example.com/`)      | Optional                                            |
 | **PGADMIN\_URL**           | URL to pgAdmin database management interface used in email reports (e.g. `https://pgadmin.example.com/`)   | Optional                                            |
@@ -273,7 +273,7 @@ Now in the `.env`, we can specify the path to the volume inside the container (o
 # .env
 
 STORAGE_PATH_1=/mnt/opt
-STORAGE_NICK_1=sam-fedserver01-opt
+STORAGE_NICK_1=fedserver01-opt
 ```
 
 > [!TIP]
@@ -699,7 +699,7 @@ curl -X GET https://your-backrest-reporter-instance/get-latest-storage-stats \
 [
     {
         "location": "/mnt/opt",
-        "nickname": "sam-fedserver01-opt",
+        "nickname": "fedserver01-opt",
         "current": {
             "used_bytes": 181917847552,
             "free_bytes": 296481320960,
@@ -725,13 +725,77 @@ curl -X GET https://your-backrest-reporter-instance/get-latest-storage-stats \
     },
     {
         "location": "/mnt/mnt",
-        "nickname": "sam-fedserver01 External Drive 01",
+        "nickname": "fedserver01 External Drive 01",
         "current": {
             "used_bytes": 32433807360,
         ...
         }
       ...
     }
+]
+```
+
+### Get Storage Stats (Specific Date)
+Retrieves the latest storage statistics at a specific date and its previous day, week, and month.
+
+#### Example Input
+```bash
+curl -X GET https://your-backrest-reporter-instance/get-storage-stats \
+    -H "Content-Type: application/json" \
+    -H "X-API-Key: YOUR_API_KEY_FROM_ENV" \
+    -d '{
+        "end_date": "2025-07-05T12:42:12Z"
+    }'
+```
+
+#### Example Output
+```json
+[
+    {
+        "location": "/mnt-backup",
+        "nickname": "extdrive02 (Backups)",
+        "current": {
+            "used_bytes": 207065759744,
+            "free_bytes": 1753262551040,
+            "total_bytes": 1960328310784,
+            "percent_used": 10.56281024994163,
+            "time_added": "2025-07-05T11:23:15.042394Z"
+        },
+        "previous_day": {
+            "used_bytes": 206484578304,
+            "free_bytes": 1753843732480,
+            "total_bytes": 1960328310784,
+            "percent_used": 10.533163101716365,
+            "time_added": "2025-07-04T11:00:00.493426Z"
+        },
+        "previous_week": {
+            "used_bytes": 203562176512,
+            "free_bytes": 1756766134272,
+            "total_bytes": 1960328310784,
+            "percent_used": 10.384085940716163,
+            "time_added": "2025-06-28T12:14:55.262699Z"
+        },
+        "previous_month": {
+            "used_bytes": 191168102400,
+            "free_bytes": 1769160208384,
+            "total_bytes": 1960328310784,
+            "percent_used": 9.751841125201398,
+            "time_added": "2025-06-05T11:00:00.364751Z"
+        }
+    },
+    {
+        "location": "/mnt-rclone/google_drive",
+        "nickname": "rclone01",
+        "current": {
+            "used_bytes": 28077682688,
+            "free_bytes": 79296499712,
+            "total_bytes": 107374182400,
+            "percent_used": 26.14937973022461,
+            "time_added": "2025-07-05T11:23:15.273657Z"
+        },
+        ...
+    },
+    ...
 ]
 ```
 

--- a/rust-server/src/main.rs
+++ b/rust-server/src/main.rs
@@ -26,6 +26,7 @@ use handlers::{
     get_events_in_range_handler,
     get_events_in_range_totals_handler,
     get_latest_storage_stats_handler,
+    get_storage_stats_handler,
     send_test_email_handler,
     update_storage_statistics_handler,
 };
@@ -58,7 +59,9 @@ async fn main() -> anyhow::Result<()> {
 
     // Build the application router
     let app = Router::new()
-        .route("/add-event", post(add_event_handler))
+        .route(
+            "/add-event",
+            post(add_event_handler))
         .route(
             "/generate-and-send-email-report",
             post(generate_and_send_email_report),
@@ -67,7 +70,9 @@ async fn main() -> anyhow::Result<()> {
             "/get-events-and-storage-stats",
             post(get_events_and_storage_stats_handler),
         )
-        .route("/get-events-in-range", post(get_events_in_range_handler))
+        .route(
+            "/get-events-in-range",
+            post(get_events_in_range_handler))
         .route(
             "/get-events-in-range-totals",
             post(get_events_in_range_totals_handler),
@@ -76,7 +81,13 @@ async fn main() -> anyhow::Result<()> {
             "/get-latest-storage-stats",
             get(get_latest_storage_stats_handler),
         )
-        .route("/send-test-email", get(send_test_email_handler))
+        .route(
+            "/get-storage-stats",
+            post(get_storage_stats_handler),
+        )
+        .route(
+            "/send-test-email",
+            get(send_test_email_handler))
         .route(
             "/update-storage-statistics",
             get(update_storage_statistics_handler),

--- a/rust-server/src/models.rs
+++ b/rust-server/src/models.rs
@@ -43,10 +43,16 @@ pub struct SummaryPayload {
     pub snapshot_stats:  Option<SnapshotStats>,
 }
 
-/// New request type for stats
+/// Request type for snapshot event stats
 #[derive(Debug, Serialize, Deserialize)]
 pub struct StatsRequest {
     pub start_date: DateTime<Utc>,
+    pub end_date:   DateTime<Utc>,
+}
+
+/// Request type for storage stats
+#[derive(Debug, Serialize, Deserialize)]
+pub struct StorageStatsRequest {
     pub end_date:   DateTime<Utc>,
 }
 


### PR DESCRIPTION
**Summary**
- Adding handler for selecting a date to pull storage stats from
- Updating storage stats after adding each snapshot event
  - This ensures that we have updated storage stats post backup.
  - Updating all storage stats isn't the most efficient but is the easiest way to ensure storage stats are always up-to-date after backups and not involve additional mapping.

See updated `README.md` for the new `/get-storage-stats` endpoint.